### PR TITLE
Fix Duplicate Drink Bug for Seller Main Screen

### DIFF
--- a/src/main/java/usecases/sellerusecases/ModifyDrink.java
+++ b/src/main/java/usecases/sellerusecases/ModifyDrink.java
@@ -20,7 +20,11 @@ public class ModifyDrink {
             drinks = seller.getItems();
         }
         if (oldDrink != null) {
-            drinks.remove(oldDrink);
+            for(int idx = 0; idx < drinks.size(); idx ++) {
+                if (drinks.get(idx).getName().equals(oldDrink.getName())) {
+                    drinks.remove(idx);
+                }
+            }
         }
         if (newDrink != null){
             drinks.add(newDrink);

--- a/src/main/java/usecases/sellerusecases/SellerModifyDrink.java
+++ b/src/main/java/usecases/sellerusecases/SellerModifyDrink.java
@@ -30,8 +30,9 @@ public class SellerModifyDrink {
     public void modifyDrink(String name, float price, String description, String ingredient, int volume, Date productionData, Date expirationDate, float discount) {
         Drink currentDrink = new Drink(name, price, description, ingredient, volume, productionData, expirationDate, discount);
         HashMap<String, Drink> allDrinks = DrinkRuntimeDataBase.getDrinks().get(UserRuntimeDataBase.getCurrentSeller().getStoreName());
+
         // if seller modified the drink name
-        if (!Objects.equals(name, searchedDrink.getName())){
+        if (!name.equals(searchedDrink.getName())){
             allDrinks.remove(searchedDrink.getName());
             allDrinks.put(name, currentDrink);
         } else {


### PR DESCRIPTION
## Description
Compare the drink name instead of the drink object becasue the object memeory may change during the serialization process to make sure the Seller Modify Drink funtion work properly. #64 
Instead of directly deleting the drink, I changed it to a for loop to compare the drink name.

## Type of change
<!-- Please check options(put 'X' in the bracket) that are relevant. --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!-- Please check options(put 'X' in the bracket) that are relevant. --->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings